### PR TITLE
another bugfix for switch over to infura

### DIFF
--- a/lib/peer-interface.js
+++ b/lib/peer-interface.js
@@ -1147,6 +1147,67 @@ module.exports =  {
           callback(null, challenge_number );
 
         },
+        getAllMiningParameters: async function(args, callback) {
+          /* format of parameter from client:
+          args = {
+            'clientEthAddress': minerEthAddress,
+            // 'clientWorkerName': minerWorkerName,
+            'poolEthAddress': poolEthAddress,
+            'challengeNumber': poolChallengeNumber,
+            'shareTarget': poolMinimumShareTarget,
+            'shareDifficulty': poolMinimumShareDifficulty
+          }; 
+
+          Any values in the args parameter which have changed pool-side will 
+          be included in the response object. Values that are the same are
+          omitted. If keys are completely omitted from the args object they will
+          also be omitted from the response. 
+
+          Note: If 'shareTarget' or 'shareDifficulty' keys are requested, the
+          `clientEthAddress' key must be included. Otherwise it may be omitted. */
+
+          let response = {};
+
+          /* pool eth address */
+          if ("poolEthAddress" in args) {
+            let address = self.getMintingAccount().address.toString();
+            if(args.poolEthAddress != address) {
+              response.poolEthAddress = address;
+            }
+          }
+
+          /* challenge number */
+          if ("challengeNumber" in args) {
+            let challenge_number = await self.redisInterface.loadRedisData('challengeNumber');
+            /* not 100% sure why this check is here, but it can't hurt to leave it */
+            if(challenge_number!= null)
+            {
+              challenge_number = challenge_number.toString()
+            }
+            if(args.challengeNumber != challenge_number) {
+              response.challengeNumber = challenge_number;
+            }
+          }
+
+          /* difficulty */
+          if ("shareDifficulty" in args) {
+            let varDiff = await self.getMinerVarDiff(args.minerEthAddress);
+            if(args.shareDifficulty != varDiff) {
+              response.shareDifficulty = varDiff;
+            }
+          }
+
+          /* share target */
+          if ("shareTarget" in args) {
+            let varDiff = await self.getMinerVarDiff(args.minerEthAddress);
+            let share_target = self.getPoolMinimumShareTarget(varDiff).toString();
+            if(args.shareTarget != share_target) {
+              response.shareTarget = share_target;
+            }          
+          }
+
+          callback(null, response);
+        },
 
 
 

--- a/lib/transaction-coordinator.js
+++ b/lib/transaction-coordinator.js
@@ -149,7 +149,15 @@ module.exports =  {
 
     if( mined )
     {
-        success =  (web3Utils.hexToNumber( liveTransactionReceipt.status) == 1 )
+        let val_to_check = liveTransactionReceipt.status;
+        if (val_to_check === true) {
+          val_to_check = '0x1';
+        } else if (val_to_check === false) {
+          val_to_check = '0x0';
+        } else {
+          val_to_check = liveTransactionReceipt.status;
+        }
+        success =  (web3Utils.hexToNumber( val_to_check ) == 1 )
     }
 
     var receiptData = {


### PR DESCRIPTION
in transaction-coordinator we do a `web3Utils.hexToNumber( liveTransactionReceipt.status )`. When using infura `liveTransactionReceipt.status` is be a boolean which causes web3Utils.hexToNumber to throw an exception.